### PR TITLE
fix: allow pnpm 10+ to run dependency build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+onlyBuiltDependencies:   # pnpm 10
+  - better-sqlite3
+  - core-js
+  - esbuild
+  - protobufjs
+  - unrs-resolver
+allowBuilds:             # pnpm 11
+  better-sqlite3: true
+  core-js: true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true


### PR DESCRIPTION
## Problem

On a fresh `pnpm install`, pnpm 10+ blocks build scripts for native/postinstall deps by default, leaving binaries unbuilt and breaking dev/build:

```
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: better-sqlite3, core-js, esbuild, protobufjs, unrs-resolver
```

These arrive via `@tinacms/cli` / `tinacms`. Same class of bug as the Astro starter — see tinacms/tina-astro-starter#59 and tinacms/tinacms#7031.

## Fix

Add a build-script allowlist in `pnpm-workspace.yaml` covering **both** pnpm 10 (`onlyBuiltDependencies`) and pnpm 11 (`allowBuilds` — the renamed key; pnpm 11 no longer reads the `pnpm` field in `package.json`).

## Verify

`rm -rf node_modules && pnpm install` → no `ERR_PNPM_IGNORED_BUILDS`, build scripts run. Confirmed clean on pnpm 10.25.0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)